### PR TITLE
use latest embed process 1.36 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
 		<dependency>
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.process</artifactId>
-			<version>1.35</version>
+			<version>1.36-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Contains a few trailing white space removals too.
