### PR TITLE
Fixed order of testCase invocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
 						<exclude>**/live/**</exclude>
 						<exclude>**/examples/**</exclude>
 					</excludes>
+					<runOrder>alphabetical</runOrder>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
MemcachedForTestsFactoryTest has some timing issue with cleanup leading to subsequent TCs to fail. If we invoke this TC as the last one we're avoiding this problem. No real fix (will break if a TC is executed after this one) but should do it for the moment.
